### PR TITLE
Add real-time sensor analytics API and dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# .NET build outputs
+bin/
+obj/
+**/bin/
+**/obj/
+
+# Visual Studio artifacts
+.vs/
+*.user
+*.suo
+
+# Angular / Node
+node_modules/
+dist/
+.angular/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment files
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# realtime-sensor-analytics-openai-codex
+# Real-Time Sensor Analytics Dashboard
+
+This repository contains a proof-of-concept implementation of a real-time sensor analytics platform consisting of:
+
+- **Backend**: .NET 8 Web API that simulates 1,000 sensor readings per second, pushes real-time updates through SignalR, maintains a 24-hour retention policy, and exposes aggregated statistics.
+- **Frontend**: Angular 17 dashboard that visualizes streaming data, displays aggregated metrics, and highlights anomaly alerts.
+
+## Project Structure
+
+```
+/README.md
+/SensorAnalytics.sln
+/src/SensorAnalytics.Api/        # ASP.NET Core API project
+/sensor-dashboard/               # Angular SPA dashboard
+```
+
+## Backend Overview (`SensorAnalytics.Api`)
+
+- `SensorSimulationService` generates synthetic sensor data, detects anomalies, and broadcasts batches to connected clients through SignalR.
+- `SensorDataStore` maintains an in-memory buffer capable of handling 100,000 data points while enforcing a 24-hour retention window and tracking aggregate statistics.
+- `SensorHub` (SignalR) and `ReadingsController` expose real-time streams and REST endpoints for statistics, recent readings, and alerts.
+
+### Running the API
+
+```bash
+cd src/SensorAnalytics.Api
+dotnet restore
+dotnet run
+```
+
+The API listens on `http://localhost:5000` by default (adjust via `ASPNETCORE_URLS`).
+
+## Frontend Overview (`sensor-dashboard`)
+
+- Connects to the SignalR hub for live batches and keeps a rolling chart of average sensor values per second.
+- Displays aggregated statistics, a live alert feed, and a table of recent sensor readings.
+
+### Running the Dashboard
+
+```bash
+cd sensor-dashboard
+npm install
+npm start
+```
+
+By default the Angular dev server runs on `http://localhost:4200` and proxies data directly from the API.
+
+## Notes
+
+- Ensure the API is running before starting the dashboard to allow the SignalR connection to succeed.
+- The system is tuned for proof-of-concept demonstrations and can be extended with persistent storage, authentication, and production-ready deployment tooling.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository contains a proof-of-concept implementation of a real-time sensor
 ## Backend Overview (`SensorAnalytics.Api`)
 
 - `SensorSimulationService` generates synthetic sensor data, detects anomalies, and broadcasts batches to connected clients through SignalR.
-- `SensorDataStore` maintains an in-memory buffer capable of handling 100,000 data points while enforcing a 24-hour retention window and tracking aggregate statistics.
+- `SensorDataStore` maintains an in-memory buffer sized to preserve the full 24-hour retention window based on the expected ingestion rate while tracking aggregate statistics.
 - `SensorHub` (SignalR) and `ReadingsController` expose real-time streams and REST endpoints for statistics, recent readings, and alerts.
 
 ### Running the API

--- a/SensorAnalytics.sln
+++ b/SensorAnalytics.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.0.40101
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SensorAnalytics.Api", "src/SensorAnalytics.Api/SensorAnalytics.Api.csproj", "{D3512CB3-6399-4DDE-8A88-C8F911ECA95F}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {D3512CB3-6399-4DDE-8A88-C8F911ECA95F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {D3512CB3-6399-4DDE-8A88-C8F911ECA95F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {D3512CB3-6399-4DDE-8A88-C8F911ECA95F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {D3512CB3-6399-4DDE-8A88-C8F911ECA95F}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/sensor-dashboard/.browserslistrc
+++ b/sensor-dashboard/.browserslistrc
@@ -1,0 +1,4 @@
+> 0.5%
+last 2 versions
+Firefox ESR
+not dead

--- a/sensor-dashboard/angular.json
+++ b/sensor-dashboard/angular.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "sensor-dashboard": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/sensor-dashboard",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": ["zone.js"],
+            "tsConfig": "tsconfig.app.json",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2MB",
+                  "maximumError": "5MB"
+                }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "namedChunks": true
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "configurations": {
+            "production": {
+              "browserTarget": "sensor-dashboard:build:production"
+            },
+            "development": {
+              "browserTarget": "sensor-dashboard:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "browserTarget": "sensor-dashboard:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "polyfills": ["zone.js", "zone.js/testing"],
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.scss"
+            ],
+            "scripts": []
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "sensor-dashboard"
+}

--- a/sensor-dashboard/karma.conf.js
+++ b/sensor-dashboard/karma.conf.js
@@ -1,0 +1,32 @@
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {
+        random: false
+      },
+      clearContext: false
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage/sensor-dashboard'),
+      subdir: '.',
+      reporters: [{ type: 'html' }, { type: 'text-summary' }]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/sensor-dashboard/package.json
+++ b/sensor-dashboard/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "sensor-dashboard",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test",
+    "lint": "ng lint"
+  },
+  "dependencies": {
+    "@angular/animations": "^17.3.0",
+    "@angular/common": "^17.3.0",
+    "@angular/compiler": "^17.3.0",
+    "@angular/core": "^17.3.0",
+    "@angular/forms": "^17.3.0",
+    "@angular/platform-browser": "^17.3.0",
+    "@angular/platform-browser-dynamic": "^17.3.0",
+    "@angular/router": "^17.3.0",
+    "@microsoft/signalr": "^8.0.4",
+    "chart.js": "^4.4.6",
+    "ng2-charts": "^5.1.3",
+    "rxjs": "^7.8.1",
+    "tslib": "^2.6.2",
+    "zone.js": "^0.14.5"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^17.3.4",
+    "@angular/cli": "^17.3.4",
+    "@angular/compiler-cli": "^17.3.0",
+    "@types/jasmine": "^5.1.4",
+    "@types/node": "^20.12.7",
+    "jasmine-core": "^5.1.1",
+    "karma": "^6.4.2",
+    "karma-chrome-launcher": "^3.2.0",
+    "karma-coverage": "^2.2.0",
+    "karma-jasmine": "^5.1.0",
+    "karma-jasmine-html-reporter": "^2.1.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/sensor-dashboard/src/app/app.component.ts
+++ b/sensor-dashboard/src/app/app.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [RouterOutlet],
+  template: `<router-outlet></router-outlet>`,
+  styles: [
+    `:host { display: block; min-height: 100vh; background: #0f172a; color: #e2e8f0; font-family: 'Inter', sans-serif; }`
+  ]
+})
+export class AppComponent {}

--- a/sensor-dashboard/src/app/app.config.ts
+++ b/sensor-dashboard/src/app/app.config.ts
@@ -1,0 +1,9 @@
+import { ApplicationConfig } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { routes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideRouter(routes), provideHttpClient(), provideAnimations()]
+};

--- a/sensor-dashboard/src/app/app.routes.ts
+++ b/sensor-dashboard/src/app/app.routes.ts
@@ -1,0 +1,9 @@
+import { Routes } from '@angular/router';
+import { DashboardComponent } from './components/dashboard/dashboard.component';
+
+export const routes: Routes = [
+  {
+    path: '',
+    component: DashboardComponent
+  }
+];

--- a/sensor-dashboard/src/app/components/dashboard/dashboard.component.html
+++ b/sensor-dashboard/src/app/components/dashboard/dashboard.component.html
@@ -1,0 +1,109 @@
+<div class="dashboard">
+  <header class="header">
+    <div>
+      <h1>Real-Time Sensor Analytics</h1>
+      <p>Streaming 1,000 readings per second with 24-hour retention</p>
+    </div>
+    <div class="status-pill">Live</div>
+  </header>
+
+  <section class="stats-grid" *ngIf="stats$ | async as stats">
+    <div class="card stat-card">
+      <span class="label">Average Value</span>
+      <span class="value">{{ stats.averageValue | number: '1.0-2' }}</span>
+    </div>
+    <div class="card stat-card">
+      <span class="label">Value Range</span>
+      <span class="value">{{ stats.minValue | number: '1.0-2' }} – {{ stats.maxValue | number: '1.0-2' }}</span>
+    </div>
+    <div class="card stat-card">
+      <span class="label">Std Dev</span>
+      <span class="value">{{ stats.standardDeviation | number: '1.0-2' }}</span>
+    </div>
+    <div class="card stat-card">
+      <span class="label">Temperature / Humidity</span>
+      <span class="value">{{ stats.averageTemperature | number: '1.0-2' }} °C / {{ stats.averageHumidity | number: '1.0-2' }}%</span>
+    </div>
+    <div class="card stat-card">
+      <span class="label">Window Size</span>
+      <span class="value">{{ stats.totalReadings | number }} samples</span>
+      <small>Window: {{ stats.windowStart | date: 'shortTime' }} – {{ stats.windowEnd | date: 'shortTime' }}</small>
+    </div>
+  </section>
+
+  <section class="card chart-card">
+    <div class="section-header">
+      <div>
+        <h2>Live Sensor Values</h2>
+        <p>Average sensor value grouped per second across the fleet</p>
+      </div>
+    </div>
+    <div class="chart-wrapper">
+      <canvas
+        baseChart
+        [data]="chartData"
+        [options]="chartOptions"
+        [legend]="true"
+        chartType="line"
+      ></canvas>
+    </div>
+  </section>
+
+  <div class="content-grid">
+    <section class="card alerts">
+      <div class="section-header">
+        <h2>Live Alerts</h2>
+        <p>Threshold breach notifications</p>
+      </div>
+      <div class="alerts-list" *ngIf="(alerts$ | async) as alerts; else emptyAlerts">
+        <div
+          class="alert"
+          *ngFor="let alert of alerts; trackBy: trackByAlert"
+        >
+          <div class="alert-header">
+            <span class="badge">{{ alert.severity | uppercase }}</span>
+            <span class="time">{{ alert.timestamp | date: 'shortTime' }}</span>
+          </div>
+          <div class="alert-body">
+            <strong>{{ alert.sensorId }}</strong>
+            <span>{{ alert.message }}</span>
+            <span class="metric">Value: {{ alert.value | number: '1.0-2' }}</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="card readings">
+      <div class="section-header">
+        <h2>Recent Readings</h2>
+        <p>Latest sensor samples across all devices</p>
+      </div>
+      <div class="table-wrapper" *ngIf="(readings$ | async) as readings">
+        <table>
+          <thead>
+            <tr>
+              <th>Sensor</th>
+              <th>Timestamp</th>
+              <th>Value</th>
+              <th>Temp (°C)</th>
+              <th>Humidity (%)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let reading of readings.slice(-20); trackBy: trackByReading">
+              <td>{{ reading.sensorId }}</td>
+              <td>{{ reading.timestamp | date: 'mediumTime' }}</td>
+              <td>{{ reading.value | number: '1.0-2' }}</td>
+              <td>{{ reading.temperature | number: '1.0-1' }}</td>
+              <td>{{ reading.humidity | number: '1.0-1' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+</div>
+
+<ng-template #emptyAlerts>
+  <p class="empty-state">No alerts in the last few minutes. All systems nominal.</p>
+</ng-template>

--- a/sensor-dashboard/src/app/components/dashboard/dashboard.component.scss
+++ b/sensor-dashboard/src/app/components/dashboard/dashboard.component.scss
@@ -1,0 +1,195 @@
+.dashboard {
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+
+  h1 {
+    margin: 0;
+    font-size: 32px;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 4px 0 0;
+    color: rgba(226, 232, 240, 0.7);
+  }
+}
+
+.status-pill {
+  background: #22c55e;
+  color: #0f172a;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  .label {
+    font-size: 14px;
+    color: rgba(226, 232, 240, 0.6);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .value {
+    font-size: 28px;
+    font-weight: 600;
+  }
+
+  small {
+    color: rgba(226, 232, 240, 0.5);
+  }
+}
+
+.chart-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  h2 {
+    margin: 0;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 4px 0 0;
+    color: rgba(226, 232, 240, 0.6);
+  }
+}
+
+.chart-wrapper {
+  position: relative;
+  height: 320px;
+}
+
+.content-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.alerts {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.alerts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.alert {
+  border-left: 4px solid #ef4444;
+  padding-left: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  .alert-header {
+    display: flex;
+    justify-content: space-between;
+    font-size: 12px;
+    color: rgba(226, 232, 240, 0.6);
+  }
+
+  .badge {
+    background: rgba(239, 68, 68, 0.2);
+    color: #fca5a5;
+    padding: 4px 8px;
+    border-radius: 999px;
+    font-weight: 600;
+  }
+
+  .alert-body {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    strong {
+      font-size: 16px;
+    }
+
+    .metric {
+      color: rgba(226, 232, 240, 0.7);
+    }
+  }
+}
+
+.readings {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 480px;
+
+  th,
+  td {
+    padding: 12px;
+    text-align: left;
+  }
+
+  thead {
+    background: rgba(148, 163, 184, 0.1);
+    text-transform: uppercase;
+    font-size: 12px;
+    letter-spacing: 0.08em;
+  }
+
+  tbody tr:nth-child(odd) {
+    background: rgba(148, 163, 184, 0.05);
+  }
+}
+
+.empty-state {
+  color: rgba(226, 232, 240, 0.6);
+  padding: 12px;
+}
+
+@media (max-width: 768px) {
+  .dashboard {
+    padding: 16px;
+  }
+
+  .chart-wrapper {
+    height: 240px;
+  }
+}

--- a/sensor-dashboard/src/app/components/dashboard/dashboard.component.ts
+++ b/sensor-dashboard/src/app/components/dashboard/dashboard.component.ts
@@ -1,0 +1,78 @@
+import { AsyncPipe, CommonModule, DatePipe, DecimalPipe, NgFor, NgIf } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ChartConfiguration, ChartOptions } from 'chart.js';
+import { NgChartsModule } from 'ng2-charts';
+import { Subscription } from 'rxjs';
+import { SensorDataService } from '../../services/sensor-data.service';
+
+@Component({
+  selector: 'app-dashboard',
+  standalone: true,
+  imports: [CommonModule, AsyncPipe, NgChartsModule, NgIf, NgFor, DecimalPipe, DatePipe],
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.scss']
+})
+export class DashboardComponent implements OnInit, OnDestroy {
+  stats$ = this.sensorData.stats$;
+  alerts$ = this.sensorData.alerts$;
+  readings$ = this.sensorData.readings$;
+
+  chartData: ChartConfiguration<'line'>['data'] = { datasets: [], labels: [] };
+  chartOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      x: {
+        ticks: {
+          color: '#cbd5f5'
+        },
+        grid: {
+          color: 'rgba(148, 163, 184, 0.1)'
+        }
+      },
+      y: {
+        ticks: {
+          color: '#cbd5f5'
+        },
+        grid: {
+          color: 'rgba(148, 163, 184, 0.1)'
+        }
+      }
+    },
+    plugins: {
+      legend: {
+        labels: {
+          color: '#e2e8f0'
+        }
+      }
+    }
+  };
+
+  private subscriptions = new Subscription();
+
+  constructor(private readonly sensorData: SensorDataService) {}
+
+  ngOnInit(): void {
+    this.sensorData.connect();
+    this.chartData = this.sensorData.chartData;
+    this.subscriptions.add(
+      this.sensorData.readings$.subscribe(() => {
+        this.chartData = this.sensorData.chartData;
+      })
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+    this.sensorData.disconnect();
+  }
+
+  trackByAlert(_: number, alert: { id: string }): string {
+    return alert.id;
+  }
+
+  trackByReading(_: number, reading: { id: string }): string {
+    return reading.id;
+  }
+
+}

--- a/sensor-dashboard/src/app/models/alert-event.model.ts
+++ b/sensor-dashboard/src/app/models/alert-event.model.ts
@@ -1,0 +1,8 @@
+export interface AlertEvent {
+  id: string;
+  sensorId: string;
+  timestamp: string;
+  value: number;
+  message: string;
+  severity: string;
+}

--- a/sensor-dashboard/src/app/models/sensor-aggregate.model.ts
+++ b/sensor-dashboard/src/app/models/sensor-aggregate.model.ts
@@ -1,0 +1,11 @@
+export interface SensorAggregate {
+  totalReadings: number;
+  averageValue: number;
+  minValue: number;
+  maxValue: number;
+  averageTemperature: number;
+  averageHumidity: number;
+  standardDeviation: number;
+  windowStart: string;
+  windowEnd: string;
+}

--- a/sensor-dashboard/src/app/models/sensor-batch.model.ts
+++ b/sensor-dashboard/src/app/models/sensor-batch.model.ts
@@ -1,0 +1,9 @@
+import { AlertEvent } from './alert-event.model';
+import { SensorAggregate } from './sensor-aggregate.model';
+import { SensorReading } from './sensor-reading.model';
+
+export interface SensorBatch {
+  readings: SensorReading[];
+  aggregate: SensorAggregate;
+  alerts: AlertEvent[];
+}

--- a/sensor-dashboard/src/app/models/sensor-reading.model.ts
+++ b/sensor-dashboard/src/app/models/sensor-reading.model.ts
@@ -1,0 +1,8 @@
+export interface SensorReading {
+  id: string;
+  sensorId: string;
+  timestamp: string;
+  value: number;
+  temperature: number;
+  humidity: number;
+}

--- a/sensor-dashboard/src/app/services/sensor-data.service.ts
+++ b/sensor-dashboard/src/app/services/sensor-data.service.ts
@@ -151,7 +151,7 @@ export class SensorDataService implements OnDestroy {
   private updateChart(readings: SensorReading[]): void {
     readings.forEach((reading) => {
       const timestamp = new Date(reading.timestamp);
-      const key = timestamp.toISOString().substring(0, 19);
+      const key = Math.floor(timestamp.getTime() / 1000).toString();
       let bucket = this.chartBuckets.get(key);
       if (!bucket) {
         bucket = { key, timestamp, sum: 0, count: 0 };

--- a/sensor-dashboard/src/app/services/sensor-data.service.ts
+++ b/sensor-dashboard/src/app/services/sensor-data.service.ts
@@ -1,0 +1,176 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { BehaviorSubject, forkJoin } from 'rxjs';
+import {
+  HubConnection,
+  HubConnectionBuilder,
+  HubConnectionState,
+  LogLevel
+} from '@microsoft/signalr';
+import { environment } from '../../environments/environment';
+import { SensorReading } from '../models/sensor-reading.model';
+import { SensorAggregate } from '../models/sensor-aggregate.model';
+import { AlertEvent } from '../models/alert-event.model';
+import { SensorBatch } from '../models/sensor-batch.model';
+
+interface ChartBucket {
+  key: string;
+  timestamp: Date;
+  sum: number;
+  count: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class SensorDataService implements OnDestroy {
+  private readonly maxRecentReadings = 500;
+  private readonly maxAlerts = 50;
+  private readonly maxChartBuckets = 180;
+
+  private hubConnection?: HubConnection;
+
+  private readonly readingsSubject = new BehaviorSubject<SensorReading[]>([]);
+  private readonly statsSubject = new BehaviorSubject<SensorAggregate | null>(null);
+  private readonly alertsSubject = new BehaviorSubject<AlertEvent[]>([]);
+
+  private readonly chartBuckets = new Map<string, ChartBucket>();
+
+  readonly readings$ = this.readingsSubject.asObservable();
+  readonly stats$ = this.statsSubject.asObservable();
+  readonly alerts$ = this.alertsSubject.asObservable();
+
+  constructor(private readonly http: HttpClient) {}
+
+  connect(): void {
+    if (this.hubConnection && this.hubConnection.state !== HubConnectionState.Disconnected) {
+      return;
+    }
+
+    this.buildHubConnection();
+    this.registerHandlers();
+    this.startConnection();
+    this.loadInitialData();
+  }
+
+  disconnect(): void {
+    if (this.hubConnection) {
+      void this.hubConnection.stop();
+      this.hubConnection = undefined;
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.disconnect();
+  }
+
+  get chartData() {
+    const sorted = Array.from(this.chartBuckets.values()).sort(
+      (a, b) => a.timestamp.getTime() - b.timestamp.getTime()
+    );
+    return {
+      labels: sorted.map((bucket) => bucket.timestamp.toLocaleTimeString()),
+      datasets: [
+        {
+          data: sorted.map((bucket) => bucket.sum / Math.max(bucket.count, 1)),
+          label: 'Average Value',
+          fill: false,
+          tension: 0.2,
+          borderColor: '#3b82f6',
+          backgroundColor: 'rgba(59, 130, 246, 0.2)',
+          pointRadius: 0
+        }
+      ]
+    };
+  }
+
+  private buildHubConnection(): void {
+    this.hubConnection = new HubConnectionBuilder()
+      .withUrl(`${environment.apiBaseUrl}/hubs/sensors`)
+      .withAutomaticReconnect([0, 2000, 5000, 10000, 30000])
+      .configureLogging(LogLevel.Information)
+      .build();
+  }
+
+  private registerHandlers(): void {
+    if (!this.hubConnection) {
+      return;
+    }
+
+    this.hubConnection.on('ReceiveSensorBatch', (payload: SensorBatch) => {
+      this.processBatch(payload);
+    });
+  }
+
+  private startConnection(): void {
+    if (!this.hubConnection) {
+      return;
+    }
+
+    void this.hubConnection
+      .start()
+      .catch((error) => console.error('SignalR connection error', error));
+  }
+
+  private loadInitialData(): void {
+    const stats$ = this.http.get<SensorAggregate>(`${environment.apiBaseUrl}/api/readings/stats`);
+    const alerts$ = this.http.get<AlertEvent[]>(`${environment.apiBaseUrl}/api/readings/alerts`, {
+      params: { count: this.maxAlerts.toString() }
+    });
+    const recent$ = this.http.get<SensorReading[]>(`${environment.apiBaseUrl}/api/readings/recent`, {
+      params: { count: this.maxRecentReadings.toString() }
+    });
+
+    forkJoin({ stats: stats$, alerts: alerts$, readings: recent$ }).subscribe({
+      next: ({ stats, alerts, readings }) => {
+        this.statsSubject.next(stats);
+        this.alertsSubject.next(alerts);
+        this.readingsSubject.next(readings);
+        this.updateChart(readings);
+      },
+      error: (error) => console.error('Failed to load initial analytics data', error)
+    });
+  }
+
+  private processBatch(batch: SensorBatch): void {
+    if (batch.aggregate) {
+      this.statsSubject.next(batch.aggregate);
+    }
+
+    if (Array.isArray(batch.readings) && batch.readings.length > 0) {
+      const mergedReadings = [...this.readingsSubject.value, ...batch.readings];
+      const trimmedReadings = mergedReadings.slice(-this.maxRecentReadings);
+      this.readingsSubject.next(trimmedReadings);
+      this.updateChart(batch.readings);
+    }
+
+    if (Array.isArray(batch.alerts) && batch.alerts.length > 0) {
+      const mergedAlerts = [...batch.alerts, ...this.alertsSubject.value].slice(0, this.maxAlerts);
+      this.alertsSubject.next(mergedAlerts);
+    }
+  }
+
+  private updateChart(readings: SensorReading[]): void {
+    readings.forEach((reading) => {
+      const timestamp = new Date(reading.timestamp);
+      const key = timestamp.toISOString().substring(0, 19);
+      let bucket = this.chartBuckets.get(key);
+      if (!bucket) {
+        bucket = { key, timestamp, sum: 0, count: 0 };
+        this.chartBuckets.set(key, bucket);
+      }
+
+      bucket.sum += reading.value;
+      bucket.count += 1;
+    });
+
+    if (this.chartBuckets.size > this.maxChartBuckets) {
+      const sortedKeys = Array.from(this.chartBuckets.keys()).sort();
+      while (this.chartBuckets.size > this.maxChartBuckets) {
+        const oldestKey = sortedKeys.shift();
+        if (!oldestKey) {
+          break;
+        }
+        this.chartBuckets.delete(oldestKey);
+      }
+    }
+  }
+}

--- a/sensor-dashboard/src/environments/environment.development.ts
+++ b/sensor-dashboard/src/environments/environment.development.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'http://localhost:5000'
+};

--- a/sensor-dashboard/src/environments/environment.prod.ts
+++ b/sensor-dashboard/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiBaseUrl: 'http://localhost:5000'
+};

--- a/sensor-dashboard/src/environments/environment.ts
+++ b/sensor-dashboard/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiBaseUrl: 'http://localhost:5000'
+};

--- a/sensor-dashboard/src/index.html
+++ b/sensor-dashboard/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Sensor Dashboard</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/sensor-dashboard/src/main.ts
+++ b/sensor-dashboard/src/main.ts
@@ -1,0 +1,5 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+import { appConfig } from './app/app.config';
+
+bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));

--- a/sensor-dashboard/src/styles.scss
+++ b/sensor-dashboard/src/styles.scss
@@ -1,0 +1,21 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+html, body {
+  height: 100%;
+  margin: 0;
+  background: #0f172a;
+  color: #e2e8f0;
+  font-family: 'Inter', sans-serif;
+}
+
+a {
+  color: inherit;
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: 16px;
+  padding: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.4);
+}

--- a/sensor-dashboard/src/test.ts
+++ b/sensor-dashboard/src/test.ts
@@ -1,0 +1,4 @@
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());

--- a/sensor-dashboard/tsconfig.app.json
+++ b/sensor-dashboard/tsconfig.app.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts",
+    "src/**/*.ts"
+  ]
+}

--- a/sensor-dashboard/tsconfig.json
+++ b/sensor-dashboard/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "module": "es2022",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["es2022", "dom"],
+    "skipLibCheck": true
+  }
+}

--- a/sensor-dashboard/tsconfig.spec.json
+++ b/sensor-dashboard/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc/spec",
+    "types": ["jasmine", "node"]
+  },
+  "files": ["src/test.ts"],
+  "include": ["src/**/*.spec.ts", "src/**/*.d.ts"]
+}

--- a/src/SensorAnalytics.Api/Controllers/ReadingsController.cs
+++ b/src/SensorAnalytics.Api/Controllers/ReadingsController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+using SensorAnalytics.Api.Models;
+using SensorAnalytics.Api.Services;
+
+namespace SensorAnalytics.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ReadingsController : ControllerBase
+{
+    private readonly SensorDataStore _dataStore;
+
+    public ReadingsController(SensorDataStore dataStore)
+    {
+        _dataStore = dataStore;
+    }
+
+    [HttpGet("stats")]
+    public ActionResult<SensorAggregate> GetStats()
+    {
+        return Ok(_dataStore.GetAggregate());
+    }
+
+    [HttpGet("recent")]
+    public ActionResult<IEnumerable<SensorReading>> GetRecent([FromQuery] int count = 100)
+    {
+        return Ok(_dataStore.GetRecentReadings(count));
+    }
+
+    [HttpGet("alerts")]
+    public ActionResult<IEnumerable<AlertEvent>> GetAlerts([FromQuery] int count = 50)
+    {
+        return Ok(_dataStore.GetRecentAlerts(count));
+    }
+}

--- a/src/SensorAnalytics.Api/Hubs/SensorHub.cs
+++ b/src/SensorAnalytics.Api/Hubs/SensorHub.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace SensorAnalytics.Api.Hubs;
+
+public class SensorHub : Hub
+{
+    public const string StreamEvent = "ReceiveSensorBatch";
+}

--- a/src/SensorAnalytics.Api/Models/AlertEvent.cs
+++ b/src/SensorAnalytics.Api/Models/AlertEvent.cs
@@ -1,0 +1,9 @@
+namespace SensorAnalytics.Api.Models;
+
+public record AlertEvent(
+    Guid Id,
+    string SensorId,
+    DateTime Timestamp,
+    double Value,
+    string Message,
+    string Severity);

--- a/src/SensorAnalytics.Api/Models/SensorAggregate.cs
+++ b/src/SensorAnalytics.Api/Models/SensorAggregate.cs
@@ -1,0 +1,12 @@
+namespace SensorAnalytics.Api.Models;
+
+public record SensorAggregate(
+    int TotalReadings,
+    double AverageValue,
+    double MinValue,
+    double MaxValue,
+    double AverageTemperature,
+    double AverageHumidity,
+    double StandardDeviation,
+    DateTime WindowStart,
+    DateTime WindowEnd);

--- a/src/SensorAnalytics.Api/Models/SensorReading.cs
+++ b/src/SensorAnalytics.Api/Models/SensorReading.cs
@@ -10,6 +10,4 @@ public record SensorReading(
     double Temperature,
     double Humidity)
 {
-    [JsonIgnore]
-    public bool IsAnomaly { get; init; }
 }

--- a/src/SensorAnalytics.Api/Models/SensorReading.cs
+++ b/src/SensorAnalytics.Api/Models/SensorReading.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace SensorAnalytics.Api.Models;
+
+public record SensorReading(
+    Guid Id,
+    string SensorId,
+    DateTime Timestamp,
+    double Value,
+    double Temperature,
+    double Humidity)
+{
+    [JsonIgnore]
+    public bool IsAnomaly { get; init; }
+}

--- a/src/SensorAnalytics.Api/Program.cs
+++ b/src/SensorAnalytics.Api/Program.cs
@@ -1,0 +1,37 @@
+using SensorAnalytics.Api.Hubs;
+using SensorAnalytics.Api.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddSignalR();
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("frontend", policy =>
+    {
+        policy.WithOrigins("http://localhost:4200")
+            .AllowAnyHeader()
+            .AllowAnyMethod()
+            .AllowCredentials();
+    });
+});
+
+builder.Services.AddSingleton<SensorDataStore>();
+builder.Services.AddHostedService<SensorSimulationService>();
+
+var app = builder.Build();
+
+app.UseCors("frontend");
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapControllers();
+app.MapHub<SensorHub>("/hubs/sensors");
+
+app.Run();

--- a/src/SensorAnalytics.Api/Program.cs
+++ b/src/SensorAnalytics.Api/Program.cs
@@ -18,7 +18,8 @@ builder.Services.AddCors(options =>
     });
 });
 
-builder.Services.AddSingleton<SensorDataStore>();
+builder.Services.AddSingleton(provider => new SensorDataStore(
+    expectedIngestionRatePerSecond: SensorSimulationService.ReadingsPerSecond));
 builder.Services.AddHostedService<SensorSimulationService>();
 
 var app = builder.Build();

--- a/src/SensorAnalytics.Api/Properties/launchSettings.json
+++ b/src/SensorAnalytics.Api/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "SensorAnalytics.Api": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/SensorAnalytics.Api/SensorAnalytics.Api.csproj
+++ b/src/SensorAnalytics.Api/SensorAnalytics.Api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/src/SensorAnalytics.Api/Services/SensorDataStore.cs
+++ b/src/SensorAnalytics.Api/Services/SensorDataStore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using SensorAnalytics.Api.Models;
 
@@ -20,10 +21,17 @@ public class SensorDataStore
     private double _minValue = double.MaxValue;
     private double _maxValue = double.MinValue;
 
-    public SensorDataStore(TimeSpan? retention = null, int maxDataPoints = 100_000, int maxAlertHistory = 200)
+    public SensorDataStore(
+        TimeSpan? retention = null,
+        int? maxDataPoints = null,
+        int maxAlertHistory = 200,
+        double expectedIngestionRatePerSecond = 1_000)
     {
         _retention = retention ?? TimeSpan.FromHours(24);
-        _maxDataPoints = maxDataPoints;
+        var calculatedCapacity = CalculateCapacity(_retention, expectedIngestionRatePerSecond);
+        _maxDataPoints = maxDataPoints.HasValue
+            ? Math.Max(maxDataPoints.Value, calculatedCapacity)
+            : calculatedCapacity;
         _maxAlertHistory = maxAlertHistory;
     }
 
@@ -143,5 +151,26 @@ public class SensorDataStore
             _minValue = _readings.Min(r => r.Value);
             _maxValue = _readings.Max(r => r.Value);
         }
+    }
+
+    private static int CalculateCapacity(TimeSpan retention, double expectedIngestionRatePerSecond)
+    {
+        if (retention <= TimeSpan.Zero)
+        {
+            return 1;
+        }
+
+        if (expectedIngestionRatePerSecond <= 0)
+        {
+            return int.MaxValue;
+        }
+
+        var required = (long)Math.Ceiling(retention.TotalSeconds * expectedIngestionRatePerSecond);
+        if (required <= 0)
+        {
+            return 1;
+        }
+
+        return required > int.MaxValue ? int.MaxValue : (int)required;
     }
 }

--- a/src/SensorAnalytics.Api/Services/SensorDataStore.cs
+++ b/src/SensorAnalytics.Api/Services/SensorDataStore.cs
@@ -1,0 +1,147 @@
+using System.Linq;
+using SensorAnalytics.Api.Models;
+
+namespace SensorAnalytics.Api.Services;
+
+public class SensorDataStore
+{
+    private readonly Queue<SensorReading> _readings = new();
+    private readonly LinkedList<AlertEvent> _alerts = new();
+    private readonly object _lock = new();
+
+    private readonly TimeSpan _retention;
+    private readonly int _maxDataPoints;
+    private readonly int _maxAlertHistory;
+
+    private double _sumValue;
+    private double _sumTemperature;
+    private double _sumHumidity;
+    private double _sumValueSquared;
+    private double _minValue = double.MaxValue;
+    private double _maxValue = double.MinValue;
+
+    public SensorDataStore(TimeSpan? retention = null, int maxDataPoints = 100_000, int maxAlertHistory = 200)
+    {
+        _retention = retention ?? TimeSpan.FromHours(24);
+        _maxDataPoints = maxDataPoints;
+        _maxAlertHistory = maxAlertHistory;
+    }
+
+    public void AddReading(SensorReading reading)
+    {
+        lock (_lock)
+        {
+            PurgeExpired(reading.Timestamp);
+
+            if (_readings.Count >= _maxDataPoints)
+            {
+                RemoveOldest();
+            }
+
+            _readings.Enqueue(reading);
+            _sumValue += reading.Value;
+            _sumTemperature += reading.Temperature;
+            _sumHumidity += reading.Humidity;
+            _sumValueSquared += reading.Value * reading.Value;
+            if (reading.Value < _minValue)
+            {
+                _minValue = reading.Value;
+            }
+
+            if (reading.Value > _maxValue)
+            {
+                _maxValue = reading.Value;
+            }
+        }
+    }
+
+    public void AddAlert(AlertEvent alert)
+    {
+        lock (_lock)
+        {
+            _alerts.AddFirst(alert);
+            while (_alerts.Count > _maxAlertHistory)
+            {
+                _alerts.RemoveLast();
+            }
+        }
+    }
+
+    public IReadOnlyList<SensorReading> GetRecentReadings(int count)
+    {
+        lock (_lock)
+        {
+            return _readings.TakeLast(Math.Min(count, _readings.Count)).ToArray();
+        }
+    }
+
+    public IReadOnlyList<AlertEvent> GetRecentAlerts(int count)
+    {
+        lock (_lock)
+        {
+            return _alerts.Take(count).ToArray();
+        }
+    }
+
+    public SensorAggregate GetAggregate()
+    {
+        lock (_lock)
+        {
+            if (_readings.Count == 0)
+            {
+                var now = DateTime.UtcNow;
+                return new SensorAggregate(0, 0, 0, 0, 0, 0, 0, now, now);
+            }
+
+            var windowStart = _readings.Peek().Timestamp;
+            var windowEnd = _readings.Last().Timestamp;
+            var count = _readings.Count;
+            var average = _sumValue / count;
+            var avgTemp = _sumTemperature / count;
+            var avgHumidity = _sumHumidity / count;
+            var variance = (_sumValueSquared / count) - (average * average);
+            var stdDev = Math.Sqrt(Math.Max(variance, 0));
+
+            return new SensorAggregate(
+                count,
+                average,
+                _minValue,
+                _maxValue,
+                avgTemp,
+                avgHumidity,
+                stdDev,
+                windowStart,
+                windowEnd);
+        }
+    }
+
+    private void PurgeExpired(DateTime currentTimestamp)
+    {
+        while (_readings.Count > 0 && currentTimestamp - _readings.Peek().Timestamp > _retention)
+        {
+            RemoveOldest();
+        }
+    }
+
+    private void RemoveOldest()
+    {
+        var removed = _readings.Dequeue();
+        _sumValue -= removed.Value;
+        _sumTemperature -= removed.Temperature;
+        _sumHumidity -= removed.Humidity;
+        _sumValueSquared -= removed.Value * removed.Value;
+
+        if (Math.Abs(removed.Value - _minValue) < double.Epsilon || Math.Abs(removed.Value - _maxValue) < double.Epsilon)
+        {
+            if (_readings.Count == 0)
+            {
+                _minValue = double.MaxValue;
+                _maxValue = double.MinValue;
+                return;
+            }
+
+            _minValue = _readings.Min(r => r.Value);
+            _maxValue = _readings.Max(r => r.Value);
+        }
+    }
+}

--- a/src/SensorAnalytics.Api/Services/SensorSimulationService.cs
+++ b/src/SensorAnalytics.Api/Services/SensorSimulationService.cs
@@ -10,7 +10,7 @@ namespace SensorAnalytics.Api.Services;
 public class SensorSimulationService : BackgroundService
 {
     private const int SensorsPerBatch = 10;
-    private const int ReadingsPerSecond = 1000;
+    public const int ReadingsPerSecond = 1_000;
     private readonly ILogger<SensorSimulationService> _logger;
     private readonly SensorDataStore _dataStore;
     private readonly IHubContext<SensorHub> _hubContext;

--- a/src/SensorAnalytics.Api/Services/SensorSimulationService.cs
+++ b/src/SensorAnalytics.Api/Services/SensorSimulationService.cs
@@ -1,0 +1,116 @@
+using System.Linq;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using SensorAnalytics.Api.Hubs;
+using SensorAnalytics.Api.Models;
+
+namespace SensorAnalytics.Api.Services;
+
+public class SensorSimulationService : BackgroundService
+{
+    private const int SensorsPerBatch = 10;
+    private const int ReadingsPerSecond = 1000;
+    private readonly ILogger<SensorSimulationService> _logger;
+    private readonly SensorDataStore _dataStore;
+    private readonly IHubContext<SensorHub> _hubContext;
+    private readonly Random _random = new();
+    private readonly string[] _sensorIds = Enumerable.Range(1, SensorsPerBatch)
+        .Select(i => $"sensor-{i:000}").ToArray();
+
+    public SensorSimulationService(
+        ILogger<SensorSimulationService> logger,
+        SensorDataStore dataStore,
+        IHubContext<SensorHub> hubContext)
+    {
+        _logger = logger;
+        _dataStore = dataStore;
+        _hubContext = hubContext;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Starting sensor simulation service");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var timestamp = DateTime.UtcNow;
+                var readings = GenerateBatch(timestamp).ToList();
+                var alerts = new List<AlertEvent>();
+
+                foreach (var reading in readings)
+                {
+                    _dataStore.AddReading(reading);
+                    if (IsAnomaly(reading))
+                    {
+                        var alert = new AlertEvent(
+                            reading.Id,
+                            reading.SensorId,
+                            reading.Timestamp,
+                            reading.Value,
+                            $"Anomalous value detected: {reading.Value:F2}",
+                            "critical");
+                        alerts.Add(alert);
+                        _dataStore.AddAlert(alert);
+                    }
+                }
+
+                var aggregate = _dataStore.GetAggregate();
+
+                await _hubContext.Clients.All.SendAsync(
+                    SensorHub.StreamEvent,
+                    new
+                    {
+                        readings,
+                        aggregate,
+                        alerts
+                    },
+                    cancellationToken: stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // normal during shutdown
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error while generating sensor readings");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+        }
+    }
+
+    private IEnumerable<SensorReading> GenerateBatch(DateTime timestamp)
+    {
+        var interval = 1.0 / ReadingsPerSecond;
+        for (var i = 0; i < ReadingsPerSecond; i++)
+        {
+            var readingTimestamp = timestamp.AddSeconds(i * interval);
+            var sensorId = _sensorIds[i % _sensorIds.Length];
+            var baseValue = 50 + 10 * Math.Sin((timestamp - DateTime.UnixEpoch).TotalSeconds / 30.0);
+            var value = baseValue + _random.NextDouble() * 10 - 5;
+            if (_random.NextDouble() < 0.01)
+            {
+                value += _random.NextDouble() * 80 - 40;
+            }
+
+            var temperature = 20 + _random.NextDouble() * 5;
+            var humidity = 50 + _random.NextDouble() * 10;
+
+            yield return new SensorReading(
+                Guid.NewGuid(),
+                sensorId,
+                readingTimestamp,
+                value,
+                temperature,
+                humidity);
+        }
+    }
+
+    private static bool IsAnomaly(SensorReading reading)
+    {
+        return reading.Value is < 15 or > 85;
+    }
+}

--- a/src/SensorAnalytics.Api/appsettings.json
+++ b/src/SensorAnalytics.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- add a .NET 8 Web API that simulates 1,000 sensor readings per second, maintains 24-hour retention, and broadcasts batches via SignalR
- expose aggregated statistics, recent readings, and alert history through REST endpoints backed by an in-memory data store
- create an Angular dashboard with a live chart, rolling statistics, and anomaly alerts fed by the SignalR stream

## Testing
- not run (environment lacks the required SDKs and npm packages)

------
https://chatgpt.com/codex/tasks/task_e_68e27b5be9408331b7b0f777c251500d